### PR TITLE
Enable device selection with web serial

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,10 +67,6 @@
           data-toggle="modal"
           data-target="#options-modal"
           style="margin-right: 5px;"> Options </button>
-        <select class="custom-select mb-2 mr-sm-2 mb-sm-0"
-          id="device-select">
-          <option value="-1" selected="selected">No Serial Ports</option>
-        </select>
         <button class="btn btn-outline-success my-2 my-sm-0"
           id="connect">Connect</button>
       </div>


### PR DESCRIPTION
We now prompt the user through web serial to connect to a port and show the device name to the user.

### How to test
- [ ] pull this branch
- [ ] navigate to file:///path/to/Telemetry/index.html
- [ ] close the chrome extension prompt and click the green `Connect`. you should be prompted to select a serial port from `/dev/tty...`
![image](https://user-images.githubusercontent.com/36345325/153726837-022be0c7-8c7e-4512-8eb4-047d654ea5ef.png)

- [ ] select `/dev/ttyUSB0`. after doing so a new menu will appear to select a device on that serial port.
- [ ] after selecting above device, the prompt will close and the connect button will show the device name 
![image](https://user-images.githubusercontent.com/36345325/153726820-bb5ad5b4-7eac-4b8f-b4e6-c3314f499c74.png)

