### PR TITLE
Remove Chrome App Installation Modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,8 +41,6 @@
     <a class="navbar-brand"
       href="#"> Telemetry <span class='supsub'>
         <sup class='superscript'>version 1.4</sup>
-        <sub class="subscript disconnected-text"
-          id="app-connection-indicator"></sub>
       </span>
       <button class="btn btn-outline-warning"
         data-toggle="modal"
@@ -190,44 +188,6 @@
             data-toggle="modal"
             data-target="#not-connected-modal">
             Show Chrome Installation Instructions</button>
-          <button type="button"
-            class="btn btn-default"
-            data-dismiss="modal">Close</button>
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Chrome App Installation Modal -->
-  <div id="not-connected-modal"
-    class="modal fade"
-    role="dialog">
-    <div class="modal-dialog modal-md">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4 class="modal-title" id="chrome-app-title">
-            Chrome App Is Not Connected</h4>
-          <button type="button"
-            class="close"
-            data-dismiss="modal">&times;</button>
-        </div>
-        <div class="modal-body">
-          <h4>Telemetry App Installation Steps:</h4>
-          <ol>
-            <li>Create a new tab or window and enter
-              <code>chrome://extensions</code> into your address bar.</li>
-            <li>On the upper right hand corner, enable "Developer Mode".</li>
-            <li>Download the
-              <a href="https://github.com/SJSU-Dev2/Telemetry/raw/master/telemetry-chrome-interface.crx">telemetry-chrome-interface.crx</a> file to your
-              computer. Ignore the download warnings, the file is safe.</li>
-            <li>Drag and drop the <strong>telemetry-chrome-interface.crx</strong> file
-              into the chrome extension page and add it to your list of
-              apps.</li>
-            <li>Done, go back to the
-              <a href="https://SJSU-Dev2.github.io/Telemetry">
-                sjsu-dev2.github.io/Telemetry</a> and refresh the page</li>
-          </ol>
-        </div>
-        <div class="modal-footer">
           <button type="button"
             class="btn btn-default"
             data-dismiss="modal">Close</button>

--- a/web-app-resources/dashboard.css
+++ b/web-app-resources/dashboard.css
@@ -174,17 +174,6 @@ hr
   margin-bottom: 10px;
 }
 
-.connected-text:after
-{
-  color: lime;
-  content: "chrome app";
-}
-.disconnected-text:after
-{
-  color: red;
-  content: "chrome app";
-}
-
 .clear-btn
 {
   height: calc(2.25rem + 2px);

--- a/web-app-resources/main.js
+++ b/web-app-resources/main.js
@@ -382,48 +382,6 @@ function main()
   term.fit();
 
   flags.initialize();
-  let app_id = flags.get("chrome-app-id");
-  console.debug("chrome-app-id = ", app_id);
-
-  if (!app_id) {
-    app_id = CHROME_EXTENSION_ID;
-    console.debug("Using CHROME_EXTENSION_ID:", app_id);
-  }
-  // Check the version of the app, and if a valid response comes back, attempt
-  // to connect to the app.
-  try {
-    chrome.runtime.sendMessage(app_id, "version", (response) =>
-    {
-      if (response && response.version.toString() == APP_VERSION) {
-        serial_extension = chrome.runtime.connect(
-          app_id,
-          { name: GenerateConnectionId() }
-        );
-        let app_connection = document.querySelector("#app-connection-indicator");
-        app_connection.classList.remove("disconnected-text");
-        app_connection.classList.add("connected-text");
-        serial_extension.onMessage.addListener(chromeAppMessageHandler);
-      } else {
-        $("#chrome-app-title").text("Chrome App Out of Date!");
-        $("#not-connected-modal").modal("show");
-        serial_extension = {
-          postMessage: () =>
-          {
-            $("#not-connected-modal").modal("show");
-          }
-        };
-      }
-    });
-  } catch (e) {
-    $("#not-connected-modal").modal("show");
-    $("#chrome-app-title").text("Chrome App Is Not Connected!");
-    serial_extension = {
-      postMessage: () =>
-      {
-        $("#not-connected-modal").modal("show");
-      }
-    };
-  }
 }
 
 $(document).on('click', '.browse', function ()


### PR DESCRIPTION
Removed chrome app connected status and modal prompting user to install the extension

### How to test
- [ ] Navigate to the telemetry html file in your browser with `file://path/to/web-serial/index.html`
- [ ] ensure there is no prompt to add the chrome extension
- [ ] ensure the status of chrome the app is removed in the top left cornet
![image](https://user-images.githubusercontent.com/36345325/160069661-60c62d0a-186a-4f76-b51d-b184e00865f9.png)
 
